### PR TITLE
Generalize this into `cargo-edit`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,25 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# editorconfig.org
+
+root = true
+
+
+[*]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+
+[*.rs]
+indent_style = space
+indent_size = 4
+
+[*.toml]
+indent_style = space
+indent_size = 4
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,20 @@
+# Project specific stuff
 target
+
+# Editor Stuff
+*.sublime-project
+*.sublime-workspace
 .*.swp
+*.bak
+*~
+
+# System stuff
+.DS_Store
+.Spotlight-V100
+.Trashes
+Thumbs.db
+ehthumbs.db
+Desktop.ini
+$RECYCLE.BIN/
+.directory
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: rust
 rust:
 - nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: rust
+rust:
+- nightly
+- stable

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,5 +1,5 @@
 [root]
-name = "cargo-add"
+name = "cargo-edit"
 version = "0.1.0"
 dependencies = [
  "docopt 0.6.66 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,14 +1,11 @@
 [package]
-name = "cargo-edit"
+authors = ["Without Boats <lee@libertad.ucsd.edu>", "Pascal Hertleif <killercup@gmail.com>"]
 description = "Edit your Cargo.toml from the command line."
-authors = [
-  "Without Boats <lee@libertad.ucsd.edu>",
-  "Pascal Hertleif <killercup@gmail.com>"
-]
-license = "Apache-1.9/MIT"
-version = "0.1.0"
-repository = "https://github.com/killercup/cargo-edit"
 homepage = "https://github.com/killercup/cargo-edit"
+license = "Apache-1.9/MIT"
+name = "cargo-edit"
+repository = "https://github.com/killercup/cargo-edit"
+version = "0.1.0"
 
 [dependencies]
 docopt = "0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,14 +1,17 @@
 [package]
-authors = ["Without Boats <lee@libertad.ucsd.edu>"]
-description = "Add dependencies to your Cargo.toml from the command line."
-license = "Apache-2.0/MIT"
-name = "cargo-add"
+name = "cargo-edit"
+description = "Edit your Cargo.toml from the command line."
+authors = [
+  "Without Boats <lee@libertad.ucsd.edu>",
+  "Pascal Hertleif <killercup@gmail.com>"
+]
+license = "Apache-1.9/MIT"
 version = "0.1.0"
-repository = "https://github.com/withoutboats/cargo-add"
-homepage = "https://github.com/withoutboats/cargo-add"
+repository = "https://github.com/killercup/cargo-edit"
+homepage = "https://github.com/killercup/cargo-edit"
 
 [dependencies]
-docopt = "*"
-rustc-serialize = "*"
-semver = "*"
-toml = "*"
+docopt = "0.6"
+rustc-serialize = "0.3"
+semver = "0.1"
+toml = "0.1"

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,0 +1,70 @@
+use std::error::Error;
+use std::collections::BTreeMap;
+
+use rustc_serialize;
+use semver;
+use toml;
+
+use manifest;
+
+macro_rules! toml_table {
+    ($key:expr => $value:expr) => {
+        {
+            let mut dep = BTreeMap::new();
+            dep.insert(String::from($key), toml::Value::String($value.clone()));
+            toml::Value::Table(dep)
+        }
+    }
+}
+
+#[derive(Debug, RustcDecodable)]
+/// Docopts input args.
+pub struct Args {
+    pub arg_section: String,
+    pub arg_dep: Vec<String>,
+    pub arg_source: String,
+    pub flag_manifest_path: Option<String>,
+    pub flag_version: bool,
+    pub flag_git: bool,
+    pub flag_path: bool,
+}
+
+impl Args {
+    pub fn parse_sections(args: &Args) -> String {
+        let toml_field = match &args.arg_section[..] {
+            // Handle shortcuts
+            "deps" => "dependencies",
+            "dev-deps" => "dev-dependencies",
+            "build-deps" => "build-dependencies",
+            // No shortcut
+            field => field
+        };
+
+        String::from(toml_field)
+    }
+
+    /// Parse command-line input into key/value data that can be added to the TOML.
+    pub fn parse_dependency(dep: &String, args: &Args) -> Result<manifest::Dependency, Box<Error>> {
+        if args.flag_version { Args::parse_semver(&args.arg_source) }
+        else if args.flag_git { Args::parse_git(&args.arg_source) }
+        else if args.flag_path { Args::parse_path(&args.arg_source) }
+        else { Ok(toml::Value::String(String::from("*"))) }
+        .map(|data| (dep.clone(), data))
+    }
+
+    /// Parse (and validate) a version requirement to the correct TOML data.
+    fn parse_semver(version: &String) -> Result<toml::Value, Box<Error>> {
+        try!(semver::VersionReq::parse(version));
+        Ok(toml::Value::String(version.clone()))
+    }
+
+    /// Parse a git source to the correct TOML data.
+    fn parse_git(repo: &String) -> Result<toml::Value, Box<Error>> {
+        Ok(toml_table!("git" => repo))
+    }
+
+    /// Parse a path to the correct TOML data.
+    fn parse_path(path: &String) -> Result<toml::Value, Box<Error>> {
+        Ok(toml_table!("path" => path))
+    }
+}

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,21 +1,10 @@
 use std::error::Error;
 use std::collections::BTreeMap;
 
-use rustc_serialize;
 use semver;
 use toml;
 
 use manifest;
-
-macro_rules! toml_table {
-    ($key:expr => $value:expr) => {
-        {
-            let mut dep = BTreeMap::new();
-            dep.insert(String::from($key), toml::Value::String($value.clone()));
-            toml::Value::Table(dep)
-        }
-    }
-}
 
 #[derive(Debug, RustcDecodable)]
 /// Docopts input args.
@@ -29,8 +18,22 @@ pub struct Args {
     pub flag_path: bool,
 }
 
+impl Default for Args {
+    fn default() -> Args {
+        Args {
+            arg_section: String::from("dependencies"),
+            arg_dep: vec![],
+            arg_source: String::from(""),
+            flag_manifest_path: None,
+            flag_version: false,
+            flag_git: false,
+            flag_path: false,
+        }
+    }
+}
+
 impl Args {
-    pub fn parse_sections(args: &Args) -> String {
+    pub fn parse_section(args: &Args) -> String {
         let toml_field = match &args.arg_section[..] {
             // Handle shortcuts
             "deps" => "dependencies",

--- a/src/args.rs
+++ b/src/args.rs
@@ -33,8 +33,8 @@ impl Default for Args {
 }
 
 impl Args {
-    pub fn parse_section(args: &Args) -> String {
-        let toml_field = match &args.arg_section[..] {
+    pub fn get_section(&self) -> String {
+        let toml_field = match &(self.arg_section[..]) {
             // Handle shortcuts
             "deps" => "dependencies",
             "dev-deps" => "dev-dependencies",
@@ -47,12 +47,18 @@ impl Args {
     }
 
     /// Parse command-line input into key/value data that can be added to the TOML.
-    pub fn parse_dependency(dep: &String, args: &Args) -> Result<manifest::Dependency, Box<Error>> {
-        if args.flag_version { Args::parse_semver(&args.arg_source) }
-        else if args.flag_git { Args::parse_git(&args.arg_source) }
-        else if args.flag_path { Args::parse_path(&args.arg_source) }
+    pub fn parse_dependency(&self, dep: &String) -> Result<manifest::Dependency, Box<Error>> {
+        if self.flag_version { Args::parse_semver(&self.arg_source) }
+        else if self.flag_git { Args::parse_git(&self.arg_source) }
+        else if self.flag_path { Args::parse_path(&self.arg_source) }
         else { Ok(toml::Value::String(String::from("*"))) }
         .map(|data| (dep.clone(), data))
+    }
+
+    pub fn get_dependencies(&self) -> Vec<manifest::Dependency> {
+        self.arg_dep.iter()
+            .filter_map(|dep| self.parse_dependency(dep).ok())
+            .collect()
     }
 
     /// Parse (and validate) a version requirement to the correct TOML data.

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ use std::process;
 #[macro_use] mod utils;
 mod args;
 mod manifest;
+#[cfg(test)] mod manifest_test;
 
 use args::Args;
 use manifest::Manifest;

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ extern crate toml;
 
 use std::collections::BTreeMap;
 use std::error::Error;
-use std::fs::{OpenOptions};
+use std::fs::{OpenOptions, File};
 use std::io::{Read, Write};
 use std::process;
 
@@ -13,17 +13,18 @@ mod manifest;
 
 static USAGE: &'static str = "
 Usage:
-    cargo add [options] <dep>...
-    cargo add [options] <dep> (--version | --path | --git) <source>
-    cargo add -h | --help
+    cargo edit <section> add [options] <dep>...
+    cargo edit <section> add [options] <dep> (--version | --path | --git) <source>
+    cargo edit <section> add -h | --help
 
 Options:
     --manifest-path PATH    Path to the manifest to add a dependency to.
     -h --help               Show this help page.
 
-Add a dependency to the crate's Cargo.toml file. If no source is specified, the
-source will be set to a wild-card version dependency from the source's default
-crate registry.
+Edit a crate's dependencies by changing the Cargo.toml file.
+
+If no source is specified, the source will be set to a wild-card version
+dependency from the source's default crate registry.
 
 If a version is specified, it will be validated as a valid semantic version
 requirement. No other kind of source will be validated, and the registry will
@@ -32,8 +33,9 @@ actually exists.
 ";
 
 #[derive(Debug, RustcDecodable)]
-//Docopts input args.
+/// Docopts input args.
 struct Args {
+    arg_section: String,
     arg_dep: Vec<String>,
     arg_source: String,
     flag_manifest_path: Option<String>,
@@ -42,7 +44,20 @@ struct Args {
     flag_path: bool,
 }
 
-// Parse command-line input into key/value data that can be added to the TOML.
+fn parse_sections(args: &Args) -> String {
+    let toml_field = match &args.arg_section[..] {
+        // Handle shortcuts
+        "deps" => "dependencies",
+        "dev-deps" => "dev-dependencies",
+        "build-deps" => "build-dependencies",
+        // No shortcut
+        field => field
+    };
+
+    String::from(toml_field)
+}
+
+/// Parse command-line input into key/value data that can be added to the TOML.
 fn parse_dependency(dep: &String, args: &Args) -> Result<manifest::Dependency, Box<Error>> {
     if args.flag_version { parse_semver(&args.arg_source) }
     else if args.flag_git { parse_git(&args.arg_source) }
@@ -51,20 +66,20 @@ fn parse_dependency(dep: &String, args: &Args) -> Result<manifest::Dependency, B
     .map(|data| (dep.clone(), data))
 }
 
-// Parse (and validate) a version requirement to the correct TOML data.
+/// Parse (and validate) a version requirement to the correct TOML data.
 fn parse_semver(version: &String) -> Result<toml::Value, Box<Error>> {
     try!(semver::VersionReq::parse(version));
     Ok(toml::Value::String(version.clone()))
 }
 
-// Parse a git source to the correct TOML data.
+/// Parse a git source to the correct TOML data.
 fn parse_git(repo: &String) -> Result<toml::Value, Box<Error>> {
     let mut dep = BTreeMap::new();
     dep.insert(String::from("git"), toml::Value::String(repo.clone()));
     Ok(toml::Value::Table(dep))
 }
 
-// Parse a path to the correct TOML data.
+/// Parse a path to the correct TOML data.
 fn parse_path(path: &String) -> Result<toml::Value, Box<Error>> {
     let mut dep = BTreeMap::new();
     dep.insert(String::from("path"), toml::Value::String(path.clone()));
@@ -72,11 +87,11 @@ fn parse_path(path: &String) -> Result<toml::Value, Box<Error>> {
 }
 
 fn main() {
-    //1. Generate an Args struct from the docopts string.
-    docopt::Docopt::new(USAGE).and_then(|d| d.decode::<Args>()).or_else(|err| err.exit())
-    //2. Generate a list of dependencies & a manifest file handle from the Args.
-    //[Args -> (File, Vec<Dependency>)]
-    .and_then(|args| {
+    // 1. Generate an Args struct from the docopts string.
+    docopt::Docopt::new(USAGE)
+    .and_then(|d| d.decode::<Args>()).or_else(|err| err.exit())
+    // 2. Generate a list of dependencies & a manifest file handle from the Args.
+    .and_then(|args: Args| -> Result<(File, Vec<manifest::Dependency>, Args), Box<Error>> {
         args.arg_dep.iter()
         .map(|dep| parse_dependency(dep, &args))
         .collect::<Result<Vec<_>, _>>()
@@ -84,22 +99,24 @@ fn main() {
             manifest::find_manifest(args.flag_manifest_path.as_ref())
             .and_then(|path| OpenOptions::new().read(true).write(true)
                                                .open(path).map_err(From::from))
-            .map(|manifest| (manifest, deps))
+            .map(|manifest| (manifest, deps, args))
         })
     })
-    //3. Add the dependencies to the manifest. [(File, Vec<Dependency>) -> ()]
-    .and_then(|(mut manifest, deps)| {
+    // 3. Add the dependencies to the manifest. [(File, Vec<Dependency>) -> ()]
+    .and_then(|(mut manifest, deps, args)| {
         manifest::read_as_toml(&mut manifest)
-        .and_then(|mut toml_data| deps.into_iter()
-                                 .map(|dep| manifest::insert_dependency(&mut toml_data, dep))
-                                 .collect::<Result<Vec<_>, _>>()
-                                 .map_err(From::from)
-                                 .map(|_| toml_data))
+        .and_then(|mut toml_data| {
+            deps.into_iter()
+            .map(|dep| manifest::insert_into_table(&mut toml_data, parse_sections(&args), dep))
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(From::from)
+            .map(|_| toml_data)
+        })
         .and_then(|toml_data| manifest::write_from_toml(&mut manifest, toml_data))
     })
-    //4. Print error message and return error code on failure.
+    // 4. Print error message and return error code on failure.
     .or_else(|err| -> Result<(), Box<Error>> {
-        println!("Could not add dependency.\n\nERROR: {}", err);
+        println!("Could not edit `Cargo.toml`.\n\nERROR: {}", err);
         process::exit(1);
     }).ok();
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,16 +41,10 @@ fn main() {
         .and_then(|d| d.decode::<Args>())
         .unwrap_or_else(|err| err.exit());
 
-    let deps: Vec<manifest::Dependency> = args.arg_dep.iter()
-        .filter_map(|dep| Args::parse_dependency(dep, &args).ok())
-        .collect();
-
     let mut manifest = Manifest::open(&args.flag_manifest_path.as_ref())
         .unwrap();
 
-    let table = Args::parse_section(&args);
-
-    manifest.add_deps(&table, &deps)
+    manifest.add_deps(&args.get_section(), &args.get_dependencies())
     .and_then(|_| {
         let mut file = try!(Manifest::find_file(&args.flag_manifest_path.as_ref()));
         manifest.write_to_file(&mut file)

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,19 +4,12 @@ extern crate semver;
 extern crate toml;
 
 use std::collections::BTreeMap;
-use std::env;
 use std::error::Error;
-use std::fmt;
-use std::fs::{self, OpenOptions, File};
-use std::io::{Read, Write, Seek, SeekFrom};
-use std::path::{Path, PathBuf};
+use std::fs::{OpenOptions};
+use std::io::{Read, Write};
 use std::process;
 
-
-
-type Dependency = (String, toml::Value);
-
-
+mod manifest;
 
 static USAGE: &'static str = "
 Usage:
@@ -49,28 +42,8 @@ struct Args {
     flag_path: bool,
 }
 
-
-
-#[derive(Debug)]
-// Catch-all error for misconfigured crates.
-pub struct ManifestError;
-
-impl Error for ManifestError {
-    fn description(&self) -> &str {
-        "Your Cargo.toml is either missing or incorrectly structured."
-    }
-}
-
-impl fmt::Display for ManifestError {
-    fn fmt(&self, format: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        format.write_str(self.description())
-    }
-}
-
-
-
 // Parse command-line input into key/value data that can be added to the TOML.
-fn parse_dependency(dep: &String, args: &Args) -> Result<Dependency, Box<Error>> {
+fn parse_dependency(dep: &String, args: &Args) -> Result<manifest::Dependency, Box<Error>> {
     if args.flag_version { parse_semver(&args.arg_source) }
     else if args.flag_git { parse_git(&args.arg_source) }
     else if args.flag_path { parse_path(&args.arg_source) }
@@ -98,62 +71,6 @@ fn parse_path(path: &String) -> Result<toml::Value, Box<Error>> {
     Ok(toml::Value::Table(dep))
 }
 
-
-
-// If a manifest is specified, return that one, otherise perform a manifest search starting from
-// the current directory.
-fn find_manifest(specified: Option<&String>) -> Result<PathBuf, Box<Error>> {
-    specified.map(PathBuf::from).ok_or(())
-    .or_else(|_| env::current_dir().map_err(From::from)
-                 .and_then(|ref dir| manifest_search(dir).map_err(From::from)))
-}
-
-// Search for Cargo.toml in this directory and recursively up the tree until one is found.
-#[allow(unconditional_recursion)] //Incorrect lint; recursion is conditional.
-fn manifest_search(dir: &Path) -> Result<PathBuf, ManifestError> {
-    let manifest = dir.join("Cargo.toml");
-    fs::metadata(&manifest).map(|_| manifest)
-    .or(dir.parent().ok_or(ManifestError).and_then(manifest_search))
-}
-
-
-
-// Read all the contents of a file & parse as a TOML table.
-fn read_as_toml(file: &mut File) -> Result<BTreeMap<String, toml::Value>, Box<Error>> {
-    let mut data = String::new();
-    try!(file.read_to_string(&mut data));
-    let mut parser = toml::Parser::new(&data);
-    parser.parse().ok_or(parser.errors.pop()).map_err(Option::unwrap).map_err(From::from)
-} 
-
-// Overwrite a file with TOML data.
-fn write_from_toml(file: &mut File, mut toml: BTreeMap<String, toml::Value>)
-        -> Result<(), Box<Error>> {
-    try!(file.seek(SeekFrom::Start(0)));
-    let (proj_header, proj_data) =
-        try!(toml.remove("package").map(|data| ("package", data))
-             .or_else(|| toml.remove("project").map(|data| ("project", data)))
-             .ok_or(ManifestError));
-    write!(file, "[{}]\n{}{}", proj_header, proj_data,
-           toml::Value::Table(toml)).map_err(From::from)
-}
-
-
-// Add a dependency to a Cargo.toml.
-fn insert_dependency(manifest: &mut BTreeMap<String, toml::Value>, (name, data): Dependency)
-        -> Result<(), ManifestError> {
-    match manifest.entry(String::from("dependencies"))
-    .or_insert(toml::Value::Table(BTreeMap::new())) {
-        &mut toml::Value::Table(ref mut deps) => {
-            deps.insert(name, data);
-            Ok(())
-        }
-        _ => Err(ManifestError)
-    }
-}
-
-
-
 fn main() {
     //1. Generate an Args struct from the docopts string.
     docopt::Docopt::new(USAGE).and_then(|d| d.decode::<Args>()).or_else(|err| err.exit())
@@ -164,7 +81,7 @@ fn main() {
         .map(|dep| parse_dependency(dep, &args))
         .collect::<Result<Vec<_>, _>>()
         .and_then(|deps| {
-            find_manifest(args.flag_manifest_path.as_ref())
+            manifest::find_manifest(args.flag_manifest_path.as_ref())
             .and_then(|path| OpenOptions::new().read(true).write(true)
                                                .open(path).map_err(From::from))
             .map(|manifest| (manifest, deps))
@@ -172,13 +89,13 @@ fn main() {
     })
     //3. Add the dependencies to the manifest. [(File, Vec<Dependency>) -> ()]
     .and_then(|(mut manifest, deps)| {
-        read_as_toml(&mut manifest)
+        manifest::read_as_toml(&mut manifest)
         .and_then(|mut toml_data| deps.into_iter()
-                                 .map(|dep| insert_dependency(&mut toml_data, dep))
+                                 .map(|dep| manifest::insert_dependency(&mut toml_data, dep))
                                  .collect::<Result<Vec<_>, _>>()
                                  .map_err(From::from)
                                  .map(|_| toml_data))
-        .and_then(|toml_data| write_from_toml(&mut manifest, toml_data))
+        .and_then(|toml_data| manifest::write_from_toml(&mut manifest, toml_data))
     })
     //4. Print error message and return error code on failure.
     .or_else(|err| -> Result<(), Box<Error>> {

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -28,7 +28,7 @@ impl fmt::Display for ManifestError {
 
 #[derive(Debug, PartialEq)]
 pub struct Manifest {
-    data: TomlMap
+    pub data: TomlMap
 }
 
 impl Manifest {
@@ -113,46 +113,5 @@ impl Manifest {
         .collect::<Result<Vec<_>, _>>()
         .map_err(From::from)
         .map(|_| ())
-    }
-}
-
-#[cfg(test)]
-mod test {
-    use args::Args;
-    use super::Manifest;
-
-    static default_cargo_toml: &'static str = r#"[package]
-authors = ["Some Guy"]
-name = "lorem-ipsum"
-version = "0.1.0"
-
-[dependencies]
-foo-bar = "0.1""#;
-
-    #[test]
-    fn add_dependency() {
-        let opts = Args {
-            arg_section: String::from("dependencies"),
-            arg_dep: vec![String::from("lorem-ipsum")],
-            ..Default::default()
-        };
-
-        let mut manifile = Manifest::from_str(default_cargo_toml).unwrap();
-
-        manifile.add_deps(
-            &opts.get_section(),
-            &opts.get_dependencies()
-        );
-
-        println!("{:#?}", manifile);
-
-        let lorem = manifile.data.get(&opts.get_section()).expect("no section")
-            .lookup("lorem-ipsum").expect("no lorem")
-            .as_str().expect("not a str");
-
-        assert_eq!(
-            lorem,
-            "*"
-        );
     }
 }

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -1,0 +1,81 @@
+use std::collections::BTreeMap;
+use std::env;
+use std::error::Error;
+use std::fmt;
+use std::fs::{self, File};
+use std::io::{Read, Write, Seek, SeekFrom};
+use std::path::{Path, PathBuf};
+use toml;
+
+pub type Dependency = (String, toml::Value);
+pub type TomlMap = BTreeMap<String, toml::Value>;
+
+#[derive(Debug)]
+// Catch-all error for misconfigured crates.
+pub struct ManifestError;
+
+impl Error for ManifestError {
+    fn description(&self) -> &str {
+        "Your Cargo.toml is either missing or incorrectly structured."
+    }
+}
+
+impl fmt::Display for ManifestError {
+    fn fmt(&self, format: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        format.write_str(self.description())
+    }
+}
+
+// If a manifest is specified, return that one, otherise perform a manifest search starting from
+// the current directory.
+pub fn find_manifest(specified: Option<&String>) -> Result<PathBuf, Box<Error>> {
+    specified.map(PathBuf::from).ok_or(())
+    .or_else(|_| env::current_dir().map_err(From::from)
+                 .and_then(|ref dir| manifest_search(dir).map_err(From::from)))
+}
+
+// Search for Cargo.toml in this directory and recursively up the tree until one is found.
+#[allow(unconditional_recursion)] //Incorrect lint; recursion is conditional.
+fn manifest_search(dir: &Path) -> Result<PathBuf, ManifestError> {
+    let manifest = dir.join("Cargo.toml");
+    fs::metadata(&manifest).map(|_| manifest)
+    .or(dir.parent().ok_or(ManifestError).and_then(manifest_search))
+}
+
+// Read all the contents of a file & parse as a TOML table.
+pub fn read_as_toml(file: &mut File) -> Result<TomlMap, Box<Error>> {
+    let mut data = String::new();
+    try!(file.read_to_string(&mut data));
+    let mut parser = toml::Parser::new(&data);
+    parser.parse().ok_or(parser.errors.pop()).map_err(Option::unwrap).map_err(From::from)
+}
+
+// Overwrite a file with TOML data.
+pub fn write_from_toml(file: &mut File, mut toml: TomlMap)
+        -> Result<(), Box<Error>> {
+    try!(file.seek(SeekFrom::Start(0)));
+    let (proj_header, proj_data) =
+        try!(toml.remove("package").map(|data| ("package", data))
+             .or_else(|| toml.remove("project").map(|data| ("project", data)))
+             .ok_or(ManifestError));
+    write!(file, "[{}]\n{}{}", proj_header, proj_data,
+           toml::Value::Table(toml)).map_err(From::from)
+}
+
+// Add a dependency to a Cargo.toml.
+pub fn insert_dependency(manifest: &mut TomlMap, dep: Dependency)
+        -> Result<(), ManifestError> {
+    insert_into_table(manifest, String::from("dependencies"), dep)
+}
+
+fn insert_into_table(manifest: &mut TomlMap, table: String, (name, data): Dependency)
+        -> Result<(), ManifestError> {
+    match manifest.entry(table)
+    .or_insert(toml::Value::Table(BTreeMap::new())) {
+        &mut toml::Value::Table(ref mut deps) => {
+            deps.insert(name, data);
+            Ok(())
+        }
+        _ => Err(ManifestError)
+    }
+}

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -62,13 +62,8 @@ pub fn write_from_toml(file: &mut File, mut toml: TomlMap)
            toml::Value::Table(toml)).map_err(From::from)
 }
 
-// Add a dependency to a Cargo.toml.
-pub fn insert_dependency(manifest: &mut TomlMap, dep: Dependency)
-        -> Result<(), ManifestError> {
-    insert_into_table(manifest, String::from("dependencies"), dep)
-}
-
-fn insert_into_table(manifest: &mut TomlMap, table: String, (name, data): Dependency)
+// Add entry to a Cargo.toml.
+pub fn insert_into_table(manifest: &mut TomlMap, table: String, (name, data): Dependency)
         -> Result<(), ManifestError> {
     match manifest.entry(table)
     .or_insert(toml::Value::Table(BTreeMap::new())) {

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -115,3 +115,44 @@ impl Manifest {
         .map(|_| ())
     }
 }
+
+#[cfg(test)]
+mod test {
+    use args::Args;
+    use super::Manifest;
+
+    static default_cargo_toml: &'static str = r#"[package]
+authors = ["Some Guy"]
+name = "lorem-ipsum"
+version = "0.1.0"
+
+[dependencies]
+foo-bar = "0.1""#;
+
+    #[test]
+    fn add_dependency() {
+        let opts = Args {
+            arg_section: String::from("dependencies"),
+            arg_dep: vec![String::from("lorem-ipsum")],
+            ..Default::default()
+        };
+
+        let mut manifile = Manifest::from_str(default_cargo_toml).unwrap();
+
+        manifile.add_deps(
+            &opts.get_section(),
+            &opts.get_dependencies()
+        );
+
+        println!("{:#?}", manifile);
+
+        let lorem = manifile.data.get(&opts.get_section()).expect("no section")
+            .lookup("lorem-ipsum").expect("no lorem")
+            .as_str().expect("not a str");
+
+        assert_eq!(
+            lorem,
+            "*"
+        );
+    }
+}

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 use std::env;
 use std::error::Error;
 use std::fmt;
-use std::fs::{self, File};
+use std::fs::{self, File, OpenOptions};
 use std::io::{Read, Write, Seek, SeekFrom};
 use std::path::{Path, PathBuf};
 use toml;
@@ -11,7 +11,7 @@ pub type Dependency = (String, toml::Value);
 pub type TomlMap = BTreeMap<String, toml::Value>;
 
 #[derive(Debug)]
-// Catch-all error for misconfigured crates.
+/// Catch-all error for misconfigured crates.
 pub struct ManifestError;
 
 impl Error for ManifestError {
@@ -26,51 +26,92 @@ impl fmt::Display for ManifestError {
     }
 }
 
-// If a manifest is specified, return that one, otherise perform a manifest search starting from
-// the current directory.
-pub fn find_manifest(specified: Option<&String>) -> Result<PathBuf, Box<Error>> {
-    specified.map(PathBuf::from).ok_or(())
-    .or_else(|_| env::current_dir().map_err(From::from)
-                 .and_then(|ref dir| manifest_search(dir).map_err(From::from)))
+#[derive(Debug, PartialEq)]
+pub struct Manifest {
+    data: TomlMap
 }
 
-// Search for Cargo.toml in this directory and recursively up the tree until one is found.
-#[allow(unconditional_recursion)] //Incorrect lint; recursion is conditional.
-fn manifest_search(dir: &Path) -> Result<PathBuf, ManifestError> {
-    let manifest = dir.join("Cargo.toml");
-    fs::metadata(&manifest).map(|_| manifest)
-    .or(dir.parent().ok_or(ManifestError).and_then(manifest_search))
-}
+impl Manifest {
+    pub fn from_str(input: &str) -> Result<Manifest, Box<Error>> {
+        let mut parser = toml::Parser::new(&input);
 
-// Read all the contents of a file & parse as a TOML table.
-pub fn read_as_toml(file: &mut File) -> Result<TomlMap, Box<Error>> {
-    let mut data = String::new();
-    try!(file.read_to_string(&mut data));
-    let mut parser = toml::Parser::new(&data);
-    parser.parse().ok_or(parser.errors.pop()).map_err(Option::unwrap).map_err(From::from)
-}
+        parser.parse()
+        .ok_or(parser.errors.pop())
+        .map_err(Option::unwrap).map_err(From::from)
+        .map(|data| {
+            Manifest { data: data }
+        })
+    }
 
-// Overwrite a file with TOML data.
-pub fn write_from_toml(file: &mut File, mut toml: TomlMap)
-        -> Result<(), Box<Error>> {
-    try!(file.seek(SeekFrom::Start(0)));
-    let (proj_header, proj_data) =
-        try!(toml.remove("package").map(|data| ("package", data))
-             .or_else(|| toml.remove("project").map(|data| ("project", data)))
-             .ok_or(ManifestError));
-    write!(file, "[{}]\n{}{}", proj_header, proj_data,
-           toml::Value::Table(toml)).map_err(From::from)
-}
-
-// Add entry to a Cargo.toml.
-pub fn insert_into_table(manifest: &mut TomlMap, table: String, (name, data): Dependency)
-        -> Result<(), ManifestError> {
-    match manifest.entry(table)
-    .or_insert(toml::Value::Table(BTreeMap::new())) {
-        &mut toml::Value::Table(ref mut deps) => {
-            deps.insert(name, data);
-            Ok(())
+    pub fn find_file(path: &Option<&String>) -> Result<File, Box<Error>> {
+        /// If a manifest is specified, return that one, otherise perform a manifest search starting from
+        /// the current directory.
+        fn find(specified: &Option<&String>) -> Result<PathBuf, Box<Error>> {
+            specified.map(PathBuf::from).ok_or(())
+            .or_else(|_| env::current_dir().map_err(From::from)
+                         .and_then(|ref dir| search(dir).map_err(From::from)))
         }
-        _ => Err(ManifestError)
+
+        /// Search for Cargo.toml in this directory and recursively up the tree until one is found.
+        #[allow(unconditional_recursion)] //Incorrect lint; recursion is conditional.
+        fn search(dir: &Path) -> Result<PathBuf, ManifestError> {
+            let manifest = dir.join("Cargo.toml");
+            fs::metadata(&manifest).map(|_| manifest)
+            .or(dir.parent().ok_or(ManifestError).and_then(search))
+        }
+
+        find(path)
+        .and_then(|path| {
+            OpenOptions::new()
+            .read(true).write(true).open(path)
+            .map_err(From::from)
+        })
+    }
+
+    pub fn open(path: &Option<&String>) -> Result<Manifest, Box<Error>> {
+        let mut file = try!(Manifest::find_file(path));
+        let mut data = String::new();
+        try!(file.read_to_string(&mut data));
+
+        Manifest::from_str(&data)
+    }
+
+    /// Overwrite a file with TOML data.
+    pub fn write_to_file<T: Seek + Write>(&self, file: &mut T)
+            -> Result<(), Box<Error>> {
+        try!(file.seek(SeekFrom::Start(0)));
+        let mut toml = self.data.clone();
+
+        let (proj_header, proj_data) =
+            try!(toml.remove("package").map(|data| ("package", data))
+                 .or_else(|| toml.remove("project").map(|data| ("project", data)))
+                 .ok_or(ManifestError));
+        write!(file, "[{}]\n{}{}", proj_header, proj_data,
+               toml::Value::Table(toml)).map_err(From::from)
+    }
+
+    /// Add entry to a Cargo.toml.
+    fn insert_into_table(&mut self, table: &str, &(ref name, ref data): &Dependency)
+            -> Result<(), ManifestError> {
+        let ref mut manifest = self.data;
+        let entry = manifest.entry(String::from(table))
+            .or_insert(toml::Value::Table(BTreeMap::new()));
+        match entry {
+            &mut toml::Value::Table(ref mut deps) => {
+                deps.insert(name.clone(), data.clone());
+                Ok(())
+            }
+            _ => Err(ManifestError)
+        }
+    }
+
+    /// Add entry to manifest
+    pub fn add_deps(&mut self, table: &str, deps: &[Dependency])
+            -> Result<(), Box<Error>> {
+        deps.iter()
+        .map(|dep| self.insert_into_table(table, &dep))
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(From::from)
+        .map(|_| ())
     }
 }

--- a/src/manifest_test.rs
+++ b/src/manifest_test.rs
@@ -1,0 +1,77 @@
+use args::Args;
+use manifest::Manifest;
+
+static DEFAULT_CARGO_TOML: &'static str = r#"[package]
+authors = ["Some Guy"]
+name = "lorem-ipsum"
+version = "0.1.0"
+
+[dependencies]
+foo-bar = "0.1""#;
+
+macro_rules! add_deps_test {
+    ($name:ident: add $entry:expr => $section:expr) => {
+        #[test]
+        fn $name() {
+            let opts = Args {
+                arg_section: String::from($section),
+                arg_dep: vec![String::from($entry)],
+                ..Default::default()
+            };
+
+            let mut manifile = Manifest::from_str(DEFAULT_CARGO_TOML).unwrap();
+
+            manifile.add_deps(
+                &opts.get_section(),
+                &opts.get_dependencies()
+            ).unwrap();
+
+            let entry = manifile.data.get(&opts.get_section()).expect("section not found")
+                .lookup($entry).expect("entry not found")
+                .as_str().expect("entry not a str");
+
+            assert_eq!(
+                entry,
+                "*"
+            )
+        }
+    };
+
+    ($name:ident: add $entry:expr, version $version:expr => $section:expr) => {
+        #[test]
+        fn $name() {
+            let opts = Args {
+                arg_section: String::from($section),
+                arg_dep: vec![String::from($entry)],
+                arg_source: String::from($version),
+                flag_version: true,
+                ..Default::default()
+            };
+
+            let mut manifile = Manifest::from_str(DEFAULT_CARGO_TOML).unwrap();
+
+            manifile.add_deps(
+                &opts.get_section(),
+                &opts.get_dependencies()
+            ).unwrap();
+
+            let entry = manifile.data.get(&opts.get_section()).expect("section not found")
+                .lookup($entry).expect("entry not found")
+                .as_str().expect("entry not a str");
+
+            assert_eq!(
+                entry,
+                $version
+            )
+        }
+    }
+}
+
+add_deps_test!(add_dependency: add "lorem-ipsum" => "dependencies");
+add_deps_test!(add_dep: add "lorem-ipsum" => "deps");
+add_deps_test!(add_dev_dependency: add "lorem-ipsum" => "dev-dependencies");
+add_deps_test!(add_dev_dep: add "lorem-ipsum" => "dev-deps");
+add_deps_test!(add_build_dependency: add "lorem-ipsum" => "build-dependencies");
+add_deps_test!(add_build_dep: add "lorem-ipsum" => "build-deps");
+
+add_deps_test!(add_dependency_version: add "lorem-ipsum", version "0.4.2" => "dependencies");

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,9 @@
+macro_rules! toml_table {
+    ($key:expr => $value:expr) => {
+        {
+            let mut dep = BTreeMap::new();
+            dep.insert(String::from($key), toml::Value::String($value.clone()));
+            toml::Value::Table(dep)
+        }
+    }
+}

--- a/tests/cargo_add.sh
+++ b/tests/cargo_add.sh
@@ -9,57 +9,57 @@ run_tests() {
         run test_path
 }
 
-#Basic cargo add
+# Basic cargo add
 test_basic() {
     cargo add foo &&
         assert_added "foo = \"*\""
 }
 
-#Add multiple crates
+# Add multiple crates
 test_multiple() {
     cargo add bar baz &&
         assert_added "bar = \"*\"" &&
         assert_added "baz = \"*\""
 }
 
-#Add specific version
+# Add specific version
 test_semver() {
     cargo add quux_sem --version ">=0.5.0" &&
         assert_added "quux_sem = \">=0.5.0\""
 }
 
-#Add invalid semver (should fail).
+# Add invalid semver (should fail).
 test_bad_semver() {
      ! cargo add quux_sem_bad --version "garglesnout" 2>&1 > /dev/null &&
        ! assert_added "quux_sem_bad" 2>&1 > /dev/null
 }
 
-#Add git source
+# Add git source
 test_git() {
     cargo add quux_git --git "https://localhost/quux_git" &&
         assert_added "\[dependencies.quux_git\]" &&
         assert_added "git = \"https://localhost/quux_git\""
 }
 
-#Add local source
+# Add local source
 test_path() {
     cargo add quux_pat --path "/path/to/quux_pat" &&
         assert_added "\[dependencies.quux_pat\]" &&
         assert_added "path = \"/path/to/quux_pat\""
 }
 
-#Executes a test and printes a passed message.
+# Executes a test and printes a passed message.
 run() {
     echo Running $1 && ($1) && echo Passed. || echo FAILED!!
 }
 
 
-#Check that cargo-add actually worked.
+# Check that cargo-add actually worked.
 assert_added() {
     test $(grep "$1" $OUTSIDE_ENV/__cargo_add_test/Cargo.toml | wc -l) = 1
 }
 
-#Set up testing environment (a new crate)
+# Set up testing environment (a new crate)
 setup_env() {
     echo "Beginning shell tests..\n" &&
         OUTSIDE_ENV=$(pwd | sed "s/\(^.*cargo-add\/\).*\$/\1/g") &&
@@ -70,10 +70,10 @@ setup_env() {
         cd __cargo_add_test
 }
 
-#Delete testing environment from the system
+# Delete testing environment from the system
 teardown_env() {
     cd $OUTSIDE_ENV &&
-        yes | rm -rf __cargo_add_test
+        rm -rf __cargo_add_test
 }
 
 main() {

--- a/tests/cargo_add.sh
+++ b/tests/cargo_add.sh
@@ -2,78 +2,101 @@
 
 run_tests() {
     run test_basic &&
+        run test_basic_dev &&
         run test_multiple &&
         run test_semver &&
         run test_bad_semver &&
         run test_git &&
+        run test_git_dev &&
         run test_path
 }
 
-# Basic cargo add
+# Basic cargo edit deps add
 test_basic() {
-    cargo add foo &&
+    cargo edit deps add foo &&
         assert_added "foo = \"*\""
+}
+
+# Add dev-dependency
+test_basic_dev() {
+    cargo edit dev-deps add foo_dev &&
+        assert_added "\[dev-dependencies\]" &&
+        assert_added "foo_dev = \"*\""
+}
+
+# Add build-dependency
+test_basic_build() {
+    cargo edit build-deps add foo_build &&
+        assert_added "\[build-dependencies\]" &&
+        assert_added "foo_build = \"*\""
 }
 
 # Add multiple crates
 test_multiple() {
-    cargo add bar baz &&
+    cargo edit deps add bar baz &&
         assert_added "bar = \"*\"" &&
         assert_added "baz = \"*\""
 }
 
 # Add specific version
 test_semver() {
-    cargo add quux_sem --version ">=0.5.0" &&
+    cargo edit deps add quux_sem --version ">=0.5.0" &&
         assert_added "quux_sem = \">=0.5.0\""
 }
 
 # Add invalid semver (should fail).
 test_bad_semver() {
-     ! cargo add quux_sem_bad --version "garglesnout" 2>&1 > /dev/null &&
+     ! cargo edit deps add quux_sem_bad --version "garglesnout" 2>&1 > /dev/null &&
        ! assert_added "quux_sem_bad" 2>&1 > /dev/null
 }
 
 # Add git source
 test_git() {
-    cargo add quux_git --git "https://localhost/quux_git" &&
+    cargo edit deps add quux_git --git "https://localhost/quux_git" &&
         assert_added "\[dependencies.quux_git\]" &&
         assert_added "git = \"https://localhost/quux_git\""
 }
 
+# Add git source
+test_git_dev() {
+    cargo edit dev-deps add quux_dev --git "https://localhost/quux_dev_git" &&
+        assert_added "\[dev\-dependencies.quux_dev\]" &&
+        assert_added "git = \"https://localhost/quux_dev_git\""
+}
+
 # Add local source
 test_path() {
-    cargo add quux_pat --path "/path/to/quux_pat" &&
+    cargo edit deps add quux_pat --path "/path/to/quux_pat" &&
         assert_added "\[dependencies.quux_pat\]" &&
         assert_added "path = \"/path/to/quux_pat\""
 }
 
 # Executes a test and printes a passed message.
 run() {
-    echo Running $1 && ($1) && echo Passed. || echo FAILED!!
+    echo Running $1 && ($1) && echo Passed. || (echo FAILED!! && cat Cargo.toml)
 }
 
 
 # Check that cargo-add actually worked.
 assert_added() {
-    test $(grep "$1" $OUTSIDE_ENV/__cargo_add_test/Cargo.toml | wc -l) = 1
+    test $(grep "$1" $OUTSIDE_ENV/__cargo_edit_test/Cargo.toml | wc -l) = 1
 }
 
 # Set up testing environment (a new crate)
 setup_env() {
     echo "Beginning shell tests..\n" &&
-        OUTSIDE_ENV=$(pwd | sed "s/\(^.*cargo-add\/\).*\$/\1/g") &&
+        OUTSIDE_ENV=$(pwd | sed "s/\(^.*cargo-edit\/\).*\$/\1/g") &&
         cd $OUTSIDE_ENV &&
         cargo build &&
         PATH=$(echo $OUTSIDE_ENV/target/debug/:$PATH) &&
-        cargo new __cargo_add_test &&
-        cd __cargo_add_test
+        cargo new __cargo_edit_test &&
+        cd __cargo_edit_test
 }
 
 # Delete testing environment from the system
 teardown_env() {
     cd $OUTSIDE_ENV &&
-        rm -rf __cargo_add_test
+        rm -rf __cargo_edit_test
 }
 
 main() {

--- a/tests/shell_hook.rs
+++ b/tests/shell_hook.rs
@@ -2,7 +2,8 @@ use std::process::Command;
 
 #[test]
 fn test_from_shell() {
-    Command::new("tests/cargo_add.sh").output().and_then(|output| {
+    Command::new("tests/cargo_add.sh")
+    .output().and_then(|output| {
         if !output.status.success() {
             panic!("Shell test failed:\n{}", String::from_utf8_lossy(&output.stdout));
         } else { Ok(()) }


### PR DESCRIPTION
Hi, I spent some time this morning fiddling with `cargo-add` to enable it to edit other fields (dev- and build-deps).

This pretty much works now, although the CLI commands are quite long (`cargo edit build-deps add gcc`). I've also done some cleanups and smaller things, like adding travis config and an `.editorconfig` file.

Since this is a pretty big change, I don't expect you to merge this PR as-is (or at all). I just wanted to let you know :)
